### PR TITLE
Update to RecallIO 1.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A simple TypeScript app using the [RecallIO](https://www.npmjs.com/package/recal
 
 - Node.js 18+
 - A RecallIO API key (sign up at [RecallIO](https://app.recallio.ai))
+- This example uses RecallIO **v1.2.4** or newer
 
 ## Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "cytoscape": "^3.32.1",
         "dotenv": "^17.1.0",
         "express": "^4.21.2",
-        "recallio": "^1.1.2"
+        "recallio": "^1.2.4"
       },
       "devDependencies": {
         "@types/express": "^4.17.23",
@@ -1322,9 +1322,9 @@
       }
     },
     "node_modules/recallio": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/recallio/-/recallio-1.1.2.tgz",
-      "integrity": "sha512-+Zk0hTk7smCxWarrnYRlfI2DU2rxT8+/WVVW4IIyr81DR/fDpoeaMKB/kxK/50sLihfoH8KnV/6kDrCeNUXQtg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/recallio/-/recallio-1.2.4.tgz",
+      "integrity": "sha512-+BXVFANHldugCKN11G10yt/ZZXexZT2AGHF5WW2qevBR97QLyHtyKgHjBNELsJkuuv9vMrJKUiW05XBXcvuazQ==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.7"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "cytoscape": "^3.32.1",
     "dotenv": "^17.1.0",
     "express": "^4.21.2",
-    "recallio": "^1.1.2"
+    "recallio": "^1.2.4"
   },
   "devDependencies": {
     "@types/express": "^4.17.23",


### PR DESCRIPTION
## Summary
- upgrade RecallIO to v1.2.4
- mention the new minimum version in README

## Testing
- `npm run build`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_688a3606c028832e90b2250cf6175b2c